### PR TITLE
bugfix deeppopulate

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -250,6 +250,7 @@ function getModelFromPath(db, model, path) {
 
     // no schema, possibly a subdocument, continues to find out
     if (!schemaPath) {
+      candidateModel = null
       return
     }
 


### PR DESCRIPTION
Hi,

I think there is an issue with the following scenario:

First schema:
```
var schemaA = new mongoose.Schema({b: {type: mongoose.Schema.Types.ObjectId, ref: 'B'}});

schemaA.plugin(deepPopulate);

var ModelA = mongoose.model('A', schema);

```

Second schema:

```
var schemaB = new mongoose.Schema({subField: {c: {type: mongoose.Schema.Types.ObjectId, ref: 'C'}}});

var ModelB = mongoose.model('B', schema);
```

Third schema:

```
var schemaC = new mongoose.Schema({
// whatever...
});

var ModelC = mongoose.model('C', schema);
```

- ```ModelA.find().deepPopulate('b').exec(myCallback)``` works fine
- ```ModelA.find().deepPopulate('b.subField.c').exec(myCallback)``` did not work and I think it should be.

I found a working solution: In the function "getModelFromPath", there is an issue with candidateModel.

When deep populating ```b.subField.c```, there are few iterations:
1. getModelFromPath('b') -> There is a schema B, it returns ModelB
2. getModelFromPath('b.subField') -> There is no schema but it returns anyways schema B. This is because ```candidateModel``` is not reset to ```null```
3. getModelFromPath('b.subField.c') -> it returns an error because actually the lib tries to populate subField (with model B) with field c


My solution : reset to null candidateModel when no schema is found:
```
function getModelFromPath(db, model, path) {
  ...
  // no schema, possibly a subdocument, continues to find out
  if (!schemaPath) {
    candidateModel = null
    return
  }
  ...
}
```

Tests pass again.

What do you think about this?