### PR TITLE
mongoose 5.x fix - uses native promise

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -89,14 +89,13 @@ module.exports = function (mongoose) {
   function createMongoosePromise(resolver) {
     var promise
 
-    // mongoose 4.1.x and up
+    // mongoose 4.1.x
     if (mongoose.Promise.ES6) {
       promise = new mongoose.Promise.ES6(resolver)
     }
-    // backward compatibility
+    // mongoose 5
     else {
-      promise = new mongoose.Promise
-      resolver(promise.resolve.bind(promise, null), promise.reject.bind(promise))
+      promise = new mongoose.Promise(resolver)
     }
 
     return promise


### PR DESCRIPTION
fixes #53 , but also breaks compatibility with mongoose < 4.1 I guess. Did't find it necessary to support a very outdated version.

see https://github.com/Automattic/mongoose/commit/938dd09d3a52f10e832929a52292a2c5b6c6f5e8#diff-4a48b88ee83836bf1814374d04bc3bbc why this change is necessary